### PR TITLE
docs: Fix a few typos

### DIFF
--- a/redis-3.0/src/endianconv.c
+++ b/redis-3.0/src/endianconv.c
@@ -8,7 +8,7 @@
  * to be backward compatible are still in big endian) because most of the
  * production environments are little endian, and we have a lot of conversions
  * in a few places because ziplists, intsets, zipmaps, need to be endian-neutral
- * even in memory, since they are serialied on RDB files directly with a single
+ * even in memory, since they are serialized on RDB files directly with a single
  * write(2) without other additional steps.
  *
  * ----------------------------------------------------------------------------

--- a/redis-3.0/src/hyperloglog.c
+++ b/redis-3.0/src/hyperloglog.c
@@ -277,7 +277,7 @@ static char *invalid_hll_err = "-INVALIDOBJ Corrupted HLL object detected\r\n";
  *  So we right shift of 0 bits (no shift in practice) and
  *  left shift the next byte of 8 bits, even if we don't use it,
  *  but this has the effect of clearing the bits so the result
- *  will not be affacted after the OR.
+ *  will not be affected after the OR.
  *
  * -------------------------------------------------------------------------
  *
@@ -661,7 +661,7 @@ int hllSparseAdd(robj *o, unsigned char *ele, size_t elesize) {
     end = p + sdslen(o->ptr) - HLL_HDR_SIZE;
 
     first = 0;
-    prev = NULL; /* Points to previos opcode at the end of the loop. */
+    prev = NULL; /* Points to previous opcode at the end of the loop. */
     next = NULL; /* Points to the next opcode at the end of the loop. */
     span = 0;
     while(p < end) {
@@ -752,8 +752,8 @@ int hllSparseAdd(robj *o, unsigned char *ele, size_t elesize) {
      * and is either currently represented by a VAL opcode with len > 1,
      * by a ZERO opcode with len > 1, or by an XZERO opcode.
      *
-     * In those cases the original opcode must be split into muliple
-     * opcodes. The worst case is an XZERO split in the middle resuling into
+     * In those cases the original opcode must be split into multiple
+     * opcodes. The worst case is an XZERO split in the middle resulting into
      * XZERO - VAL - XZERO, so the resulting sequence max length is
      * 5 bytes.
      *
@@ -953,7 +953,7 @@ double hllRawSum(uint8_t *registers, double *PE, int *ezp) {
     return E;
 }
 
-/* Return the approximated cardinality of the set based on the armonic
+/* Return the approximated cardinality of the set based on the harmonic
  * mean of the registers values. 'hdr' points to the start of the SDS
  * representing the String object holding the HLL representation.
  *

--- a/redis-3.0/src/redisassert.h
+++ b/redis-3.0/src/redisassert.h
@@ -1,4 +1,4 @@
-/* redisassert.h -- Drop in replacemnet assert.h that prints the stack trace
+/* redisassert.h -- Drop in replacement assert.h that prints the stack trace
  *                  in the Redis logs.
  *
  * This file should be included instead of "assert.h" inside libraries used by


### PR DESCRIPTION
There are small typos in:
- redis-3.0/src/endianconv.c
- redis-3.0/src/hyperloglog.c
- redis-3.0/src/redisassert.h

Fixes:
- Should read `serialized` rather than `serialied`.
- Should read `resulting` rather than `resuling`.
- Should read `replacement` rather than `replacemnet`.
- Should read `previous` rather than `previos`.
- Should read `multiple` rather than `muliple`.
- Should read `harmonic` rather than `armonic`.
- Should read `affected` rather than `affacted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md